### PR TITLE
SqureButton UI 이슈 수정

### DIFF
--- a/app/(tabs)/notes/ActionSecond.tsx
+++ b/app/(tabs)/notes/ActionSecond.tsx
@@ -88,6 +88,7 @@ const ActionSecond = () => {
                 handleSelect({ id, text, isActive: id === selectedItem?.id })
               }
               active={id === selectedItem?.id}
+              fullWidth={false}
             />
           ))}
         </View>

--- a/components/button/SquareButton.tsx
+++ b/components/button/SquareButton.tsx
@@ -9,6 +9,7 @@ type Props = {
   onPress?: () => void;
   style?: StyleProp<ViewStyle>;
   showIcon?: boolean;
+  fullWidth?: boolean;
 };
 
 const SquareButton = ({
@@ -17,10 +18,16 @@ const SquareButton = ({
   onPress,
   style,
   showIcon = true,
+  fullWidth = true,
 }: Props) => {
   return (
     <Pressable
-      style={[style, styles.button, active ? styles.active : styles.unActive]}
+      style={[
+        style,
+        styles.button,
+        active ? styles.active : styles.unActive,
+        fullWidth && { flex: 1 },
+      ]}
       onPress={onPress}
       accessibilityRole='button'
       accessibilityState={{ selected: active }}
@@ -51,7 +58,6 @@ export default SquareButton;
 
 const styles = StyleSheet.create({
   button: {
-    flex: 1,
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',


### PR DESCRIPTION
### ⚡️ 개요

- SquareButton의 flex:1 옵션 조건부로 받게 함.
- 아래 UI이슈가 대응되게함.


<img width="353" height="728" alt="image" src="https://github.com/user-attachments/assets/bbc910aa-addb-4e64-8603-ff38088f99ab" />


#### 🔥 작업사항

<!-- 해당 이슈를 위해 어떤 작업을 했는지 아래에 남겨주세요. -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

- P1: 꼭 반영해주세요 (Comment)
- P2: 적극적으로 고려해주세요 (Comment)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

## 🙋‍♂️ PR 담당자 리마인더

- [ ] 위의 P5 Rule을 숙지 하셨나요?

## 기타 사항

- 일반 머지 (Create a merge commit) 방식으로 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated button layout in the Notes Actions screen: buttons no longer stretch full width and now align with the grid as half-width tiles. This delivers a cleaner, more consistent look, improved spacing, and better tap targets.
  - Visual-only change; no impact on navigation, state, or selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->