### PR TITLE
실기기 푸시토큰을 서버에게 전달 API 연동

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -67,8 +67,6 @@ export default function RootLayout() {
 
     try {
       await api.post({ path: '/notifications/tokens', body: { token } });
-
-      // console.log('[push] token posted');
     } catch (e) {
       console.warn('[push] token post failed:', e);
     }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -13,6 +13,7 @@ import GlobalModalHost from '@/components/modal/GlobalModalHost';
 import ToastHost from '@/components/ToastHost';
 import { useAppState } from '@/hooks/useAppState';
 import { useOnlineManager } from '@/hooks/useOnlineManager';
+import { api } from '@/lib/api';
 import { registerForPushNotificationsAsync } from '@/lib/notifications';
 import { useNotificationRouting } from '@/lib/notifications/useNotificationRouting';
 import {
@@ -59,25 +60,34 @@ export default function RootLayout() {
   });
 
   const [expoPushToken, setExpoPushToken] = useState<string>('');
-  const [notification, setNotification] = useState<
-    Notifications.Notification | undefined
-  >(undefined);
+
+  // --- 토큰 전송 함수 ---
+  const postPushToken = async (token?: string) => {
+    if (!token) return;
+
+    try {
+      await api.post({ path: '/notifications/tokens', body: { token } });
+
+      // console.log('[push] token posted');
+    } catch (e) {
+      console.warn('[push] token post failed:', e);
+    }
+  };
 
   useEffect(() => {
     registerForPushNotificationsAsync()
-      .then((token) => setExpoPushToken(token ?? ''))
+      .then((token) => {
+        setExpoPushToken(token ?? '');
+        postPushToken(token);
+      })
       .catch((error: any) => setExpoPushToken(`${error}`));
 
-    const notificationListener = Notifications.addNotificationReceivedListener(
-      (notification) => setNotification(notification),
-    );
     const responseListener =
       Notifications.addNotificationResponseReceivedListener((response) => {
         console.log(response);
       });
 
     return () => {
-      notificationListener.remove();
       responseListener.remove();
     };
   }, []);

--- a/components/debug/DebugFloatingTokenButton.tsx
+++ b/components/debug/DebugFloatingTokenButton.tsx
@@ -2,6 +2,7 @@ import { schedulePushNotification } from '@/lib/notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
 import { usePathname, useRouter } from 'expo-router';
+import * as Updates from 'expo-updates';
 import React, { useState } from 'react';
 import {
   Alert,
@@ -36,6 +37,13 @@ export const DebugFloatingTokenButton = ({ token }: { token: string }) => {
     await AsyncStorage.setItem('accessToken', trimmed);
     Alert.alert('저장 완료', 'AccessToken이 AsyncStorage에 저장되었습니다.');
     Keyboard.dismiss();
+
+    // ✅ 앱 전체 reload
+    try {
+      await Updates.reloadAsync();
+    } catch (e) {
+      console.warn('reload failed', e);
+    }
   };
 
   const normalizePath = (p: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.10",
+        "expo-updates": "~0.28.17",
         "expo-web-browser": "~14.2.0",
         "google-auth-library": "^10.2.1",
         "matter-js": "^0.20.0",
@@ -5430,6 +5431,12 @@
         "node": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "license": "MIT",
@@ -5471,6 +5478,12 @@
         }
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "license": "MIT",
@@ -5498,6 +5511,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.6.tgz",
+      "integrity": "sha512-1A+do6/mLUWF9xd3uCrlXr9QFDbjbfqAYmUy8UDLOjof1lMrOhyeC4Yi6WexA/A8dhZEpIxSMCKfn7G4aHAh4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~11.0.12",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -5613,6 +5639,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
+      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "license": "MIT"
+    },
     "node_modules/expo-symbols": {
       "version": "0.4.5",
       "license": "MIT",
@@ -5641,6 +5673,49 @@
           "optional": true
         }
       }
+    },
+    "node_modules/expo-updates": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.17.tgz",
+      "integrity": "sha512-OiKDrKk6EoBRP9AoK7/4tyj9lVtHw2IfaETIFeUCHMgx5xjgKGX/jjSwqhk8N9BJgLDIy0oD0Sb0MaEbSBb3lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/config": "~11.0.13",
+        "@expo/config-plugins": "~10.1.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.14.4",
+        "expo-manifests": "~0.16.6",
+        "expo-structured-headers": "~4.1.0",
+        "expo-updates-interface": "~1.1.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
+      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
     },
     "node_modules/expo-web-browser": {
       "version": "14.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "zustand": "^5.0.7",
-    "@react-native-async-storage/async-storage": "2.1.2"
+    "@react-native-async-storage/async-storage": "2.1.2",
+    "expo-updates": "~0.28.17"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
### ⚡️ 개요

- 원래 회원가입 시점에 한번 api 호출하는게 맞는데, 회원가입 시점 파악하기가 어려워 우선 앱 접속 시마다 전달하도록 구성

#### 🔥 작업사항


- 실기기 푸시토큰을 서버에게 전달 API 연동

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

- P1: 꼭 반영해주세요 (Comment)
- P2: 적극적으로 고려해주세요 (Comment)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

## 🙋‍♂️ PR 담당자 리마인더

- [ ] 위의 P5 Rule을 숙지 하셨나요?

## 기타 사항

- 일반 머지 (Create a merge commit) 방식으로 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically uploads your push notification token after registration.
  - API requests now include your saved access token automatically.
  - Debug panel adds “AccessToken 입력 & 저장” with app reload after saving.
- Changes
  - Removed in-app foreground notification preview; response handling remains.
  - Minor UI label and layout tweaks in the debug tools.
- Chores
  - Added dependencies for secure storage and over-the-air update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->