### PR TITLE
QA 추가 수정 사항 반영

### DIFF
--- a/components/home/EmptyLetter.tsx
+++ b/components/home/EmptyLetter.tsx
@@ -1,6 +1,8 @@
 import { S3_IMAGE_URL } from '@/constants';
 import { GreyColors } from '@/constants/Colors';
+import { CARD_WIDTH, CARD_HEIGHT } from '@/constants/cardSize';
 import { Image, StyleSheet, View } from 'react-native';
+
 
 export default function EmptyTodayLetter() {
   return (
@@ -15,8 +17,8 @@ export default function EmptyTodayLetter() {
 
 const styles = StyleSheet.create({
   letterConatiner: {
-    width: 105,
-    height: 130,
+    width: CARD_WIDTH,
+    height: CARD_HEIGHT,
     position: 'relative',
     backgroundColor: 'white',
     borderRadius: 12,
@@ -28,7 +30,7 @@ const styles = StyleSheet.create({
   },
 
   letterImage: {
-    width: 80,
+    width: Math.min(80, CARD_WIDTH * 0.76), // 카드 크기에 비례해서 조정
     aspectRatio: 1,
   },
 });

--- a/components/home/MyStatusSection.tsx
+++ b/components/home/MyStatusSection.tsx
@@ -34,8 +34,7 @@ export const MyStatusSection = ({
   return (
     <View style={styles.myStatus}>
       {isMatched && hasStatus ? (
-        <>
-          <View style={styles.myStatusText}>
+        <View style={styles.myStatusText}>
             <CustomText
               variant='body2'
               fontWeight='medium'
@@ -67,7 +66,6 @@ export const MyStatusSection = ({
               </CustomText>
             </View>
           </View>
-        </>
       ) : (
         <CustomText variant='body2' color={GreyColors.grey600}>
           아직 나의 상태를 설정하지 않았어요
@@ -94,11 +92,9 @@ export const MyStatusSection = ({
 const styles = StyleSheet.create({
   myStatus: {
     height: 58,
-    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    marginHorizontal: -20,
     paddingHorizontal: 20,
     borderTopRightRadius: 20,
     borderTopLeftRadius: 20,
@@ -108,9 +104,12 @@ const styles = StyleSheet.create({
     shadowRadius: 20,
     elevation: 10,
     backgroundColor: 'white',
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
   myStatusText: {
-    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/components/home/StatusSettingModal.tsx
+++ b/components/home/StatusSettingModal.tsx
@@ -15,6 +15,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import SquareButton from '../button/SquareButton';
 
 const CARD_IN_ROW = 2;
@@ -42,27 +43,14 @@ export const StatusSettingModal = forwardRef<
     ref,
   ) => {
     const screenHeight = Dimensions.get('window').height;
-    const snapPoints = [screenHeight - 60];
+    const insets = useSafeAreaInsets();
+    const tabBarHeight = 49; // 기본 탭바 높이
+    const bottomNavHeight = tabBarHeight + insets.bottom;
+    const snapPoints = [screenHeight - bottomNavHeight];
 
     // API 데이터
     const { data: statusList, isLoading } = useStatusListQuery();
 
-    // 현재 상태에 맞는 statusId 찾기
-    const findCurrentStatusId = () => {
-      if (
-        !statusList ||
-        !currentStatus ||
-        !currentStatus.emoji ||
-        !currentStatus.text
-      )
-        return -1;
-      const currentStatusItem = statusList.find(
-        (item) =>
-          item.emoji === currentStatus.emoji &&
-          item.text === currentStatus.text,
-      );
-      return currentStatusItem?.id || -1;
-    };
 
     // 선택된 상태 관리
     const [selectedStatus, setSelectedStatus] =

--- a/components/home/TodayLetter.tsx
+++ b/components/home/TodayLetter.tsx
@@ -1,30 +1,20 @@
 import { GreyColors } from '@/constants/Colors';
+import { CARD_WIDTH, CARD_HEIGHT } from '@/constants/cardSize';
 import { LinearGradient } from 'expo-linear-gradient';
-import { Dimensions, Image, StyleSheet, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import { CustomText } from '../CustomText';
 
 interface LetterCardProps {
   url: string;
   createdAt: string;
   isRead: boolean;
-  index: number;
 }
 
-// 카드 비율 (105:130)과 화면 기반 크기 계산
-const CARD_ASPECT_RATIO = 105 / 130;
-const SCREEN_WIDTH = Dimensions.get('window').width;
-const HORIZONTAL_PADDING = 48; // 양쪽 24px씩
-const GAP_TOTAL = 24; // 12px * 2 (간격)
-const MAX_CARDS = 3;
-const AVAILABLE_WIDTH = SCREEN_WIDTH - HORIZONTAL_PADDING - GAP_TOTAL;
-const CARD_WIDTH = AVAILABLE_WIDTH / MAX_CARDS;
-const CARD_HEIGHT = CARD_WIDTH / CARD_ASPECT_RATIO;
 
 export default function LetterCard({
   url,
   createdAt,
   isRead,
-  index,
 }: LetterCardProps) {
   // 시간 차이 계산 함수
   const getTimeAgo = (dateString: string) => {

--- a/components/home/TodayLetters.tsx
+++ b/components/home/TodayLetters.tsx
@@ -3,14 +3,18 @@ import { GreyColors } from '@/constants/Colors';
 import useLatestNotesQuery from '@/hooks/api/useLatestNotesQuery';
 import { SimpleNoteResponse } from '@/types/api';
 import { router } from 'expo-router';
-import { FlatList, Pressable, StyleSheet } from 'react-native';
+import { Dimensions, FlatList, Pressable, StyleSheet } from 'react-native';
 import EmptyTodayLetter from './EmptyLetter';
 import LetterCard from './TodayLetter';
 
 const MAX_LETTER_COUNT_IN_VIWEPORT = 3;
 
+// iPhone 11 Pro 사이즈 기준 반응형 값
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const isLargeScreen = SCREEN_WIDTH >= 375;
+
 export const TodayLetters = () => {
-  const { data: latestNotes = [], isLoading } = useLatestNotesQuery();
+  const { data: latestNotes = [] } = useLatestNotesQuery();
 
   const handleCardPress = (noteId?: number) => {
     if (noteId) {
@@ -48,10 +52,8 @@ export const TodayLetters = () => {
         data={letterData}
         renderItem={({
           item,
-          index,
         }: {
           item: SimpleNoteResponse;
-          index: number;
         }) => {
           if (!item) {
             return <EmptyTodayLetter />;
@@ -63,7 +65,6 @@ export const TodayLetters = () => {
                 url={item.emotion.homeThumbnailUrl}
                 createdAt={item.createdAt}
                 isRead={item.isRead}
-                index={index}
               />
             </Pressable>
           );
@@ -80,12 +81,14 @@ const styles = StyleSheet.create({
     textAlign: 'left',
   },
   subTitle: {
-    marginBottom: 14,
+    marginBottom: isLargeScreen ? 10 : 14,
   },
   todayLetters: {
-    paddingVertical: 16,
+    paddingVertical: isLargeScreen ? 10 : 16,
     marginHorizontal: -24,
     marginBottom: 4,
+    flexGrow: 0, // 내용에 맞춰 크기 조정
+    flexShrink: 1,
   },
   todayLettersContent: {
     paddingHorizontal: 24,

--- a/constants/cardSize.ts
+++ b/constants/cardSize.ts
@@ -1,0 +1,18 @@
+import { Dimensions } from 'react-native';
+
+// 카드 기본 크기
+export const MIN_CARD_WIDTH = 105;
+export const MIN_CARD_HEIGHT = 130;
+export const CARD_ASPECT_RATIO = MIN_CARD_WIDTH / MIN_CARD_HEIGHT;
+
+// 레이아웃 상수
+export const SCREEN_WIDTH = Dimensions.get('window').width;
+export const HORIZONTAL_PADDING = 48; // 양쪽 24px씩
+export const GAP_TOTAL = 24; // 12px * 2 (간격)
+export const MAX_CARDS = 3;
+
+// 계산된 크기
+export const AVAILABLE_WIDTH = SCREEN_WIDTH - HORIZONTAL_PADDING - GAP_TOTAL;
+export const CALCULATED_CARD_WIDTH = AVAILABLE_WIDTH / MAX_CARDS;
+export const CARD_WIDTH = Math.max(MIN_CARD_WIDTH, CALCULATED_CARD_WIDTH);
+export const CARD_HEIGHT = Math.max(MIN_CARD_HEIGHT, CARD_WIDTH / CARD_ASPECT_RATIO);


### PR DESCRIPTION
### ⚡️ 개요

<!-- 어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 아래에 남겨주세요. 슬랙 스레드 링크를 첨부해주셔도 좋습니다. -->

#### 🔥 작업사항
- 작은 화면(iphone 11 pro 보다 작은 화면)에서 마음쪽지 레이아웃 수정
- 모바일 사이즈에 관계없이 바텀 시트가 하단에 위치할 수 있도록 수정
<!-- 해당 이슈를 위해 어떤 작업을 했는지 아래에 남겨주세요. -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

- P1: 꼭 반영해주세요 (Comment)
- P2: 적극적으로 고려해주세요 (Comment)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

## 🙋‍♂️ PR 담당자 리마인더

- [ ] 위의 P5 Rule을 숙지 하셨나요?

## 기타 사항

- 일반 머지 (Create a merge commit) 방식으로 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Responsive card sizes for Today/Empty Letter cards.
  - Status-setting modal now respects safe areas (e.g., tab bar) for improved visibility.
  - Dynamic label for custom status duration.

- Style
  - “My Status” section anchored to the bottom for consistent placement.
  - Responsive spacing tweaks for subtitles and letter list.
  - Letter image scales with card size for better visuals.

- Refactor
  - Unified card sizing logic for consistent layout across screens.
  - Removed unused parameters from internal components for cleaner rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->