### PR TITLE
처음 매칭할 때 리포트탭 입장 시 크래시 나는 이슈 수정

### DIFF
--- a/components/statistics/KeywordSection.tsx
+++ b/components/statistics/KeywordSection.tsx
@@ -11,8 +11,10 @@ export default function KeywordSection() {
   const { data } = useMyKeywordQuery();
 
   const { positiveActionCategory, negativeActionCategory } = data;
-  const [positiveEmoji, positiveText] = positiveActionCategory.name.split(' ');
-  const [negativeEmoji, negativeText] = negativeActionCategory.name.split(' ');
+  const [positiveEmoji, positiveText] =
+    positiveActionCategory?.name.split(' ') ?? [];
+  const [negativeEmoji, negativeText] =
+    negativeActionCategory?.name.split(' ') ?? [];
 
   const isMatched = useIsMatched();
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -275,7 +275,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - ExpoAppleAuthentication (8.0.7):
+  - ExpoAppleAuthentication (7.2.4):
     - ExpoModulesCore
   - ExpoAsset (11.1.7):
     - ExpoModulesCore
@@ -291,7 +291,7 @@ PODS:
     - ExpoModulesCore
   - ExpoHaptics (14.1.4):
     - ExpoModulesCore
-  - ExpoHead (5.1.6):
+  - ExpoHead (5.1.7):
     - ExpoModulesCore
   - ExpoImage (2.4.0):
     - ExpoModulesCore
@@ -2240,7 +2240,7 @@ PODS:
     - React-logger (= 0.79.5)
     - React-perflogger (= 0.79.5)
     - React-utils (= 0.79.5)
-  - RNCAsyncStorage (2.2.0):
+  - RNCAsyncStorage (2.1.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2501,7 +2501,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSVG (15.13.0):
+  - RNSVG (15.11.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2524,9 +2524,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNSVG/common (= 15.13.0)
+    - RNSVG/common (= 15.11.2)
     - Yoga
-  - RNSVG/common (15.13.0):
+  - RNSVG/common (15.11.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2954,7 +2954,7 @@ SPEC CHECKSUMS:
   expo-dev-launcher: 3bdbeb6102a0ebc885ef0cc1e93b8045fb46cf7c
   expo-dev-menu: 9a65836a93397539ec700e6ec99de8199ad8c4ca
   expo-dev-menu-interface: 609c35ae8b97479cdd4c9e23c8cf6adc44beea0e
-  ExpoAppleAuthentication: bc9de6e9ff3340604213ab9031d4c4f7f802623e
+  ExpoAppleAuthentication: 4d2e0c88a4463229760f1fbb9a937a810efb6863
   ExpoAsset: ef06e880126c375f580d4923fdd1cdf4ee6ee7d6
   ExpoBlur: 3c8885b9bf9eef4309041ec87adec48b5f1986a9
   ExpoClipboard: 436f6de6971f14eb75ae160e076d9cb3b19eb795
@@ -2962,7 +2962,7 @@ SPEC CHECKSUMS:
   ExpoFileSystem: 7f92f7be2f5c5ed40a7c9efc8fa30821181d9d63
   ExpoFont: cf508bc2e6b70871e05386d71cab927c8524cc8e
   ExpoHaptics: 0ff6e0d83cd891178a306e548da1450249d54500
-  ExpoHead: a35136350ff019825aa642e1e73399b417f4faed
+  ExpoHead: 520990db7d4e4a09a9142b2e03bcb08b85b97e0e
   ExpoImage: e4102c93d1dbe99ff54b075452d1bc9d6ec21b7c
   ExpoKeepAwake: bf0811570c8da182bfb879169437d4de298376e7
   ExpoLinearGradient: 7734c8059972fcf691fb4330bcdf3390960a152d
@@ -3062,7 +3062,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: f3e842e6cb5a825b6918a74a38402ba1409411f8
   ReactCodegen: 542dbcd3d677ed7c4fe69e28b7c492998f48c9db
   ReactCommon: 1aa48867a0fc71a2b4f9e8a1529f5673648354f3
-  RNCAsyncStorage: c1dca434eda758348a549efb46822b4091d76804
+  RNCAsyncStorage: 646c1bf2ebfc78d6632a3b0399f471fba8101e73
   RNDateTimePicker: cbba58b7fde72d73362a8896b9815498c8e014b2
   RNFBAnalytics: 1a27f05d7ead3197733dd507f2c6629fcf6ba9b5
   RNFBApp: 22c91c2d4ef60be1de426d3544f68c348e036bb0
@@ -3070,7 +3070,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: 8ff2b1434b0ff8bab28c8242a656fb842990bbc8
   RNReanimated: a3f55346df73f35c38bf0b446294d3d0b1ac8cf9
   RNScreens: 90b905d545a5ebbe976985702b8a39e3475727b2
-  RNSVG: d2bcb09b6a3527f6d37f0f351bc5149c69876263
+  RNSVG: 4470464e129f6bc58b78b961850b054dbbea8ef7
   SDWebImage: 9f177d83116802728e122410fb25ad88f5c7608a
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/types/api.ts
+++ b/types/api.ts
@@ -126,8 +126,8 @@ export type ActionCategoryResponse = {
 };
 
 export type KeywordResponse = {
-  positiveActionCategory: ActionCategoryResponse;
-  negativeActionCategory: ActionCategoryResponse;
+  positiveActionCategory: ActionCategoryResponse | null;
+  negativeActionCategory: ActionCategoryResponse | null;
 };
 
 export type SimpleActionChange = {


### PR DESCRIPTION
### ⚡️ 개요

<!-- 어떤 이유에서 이 PR을 시작하게 됐는지에 대한 히스토리를 아래에 남겨주세요. 슬랙 스레드 링크를 첨부해주셔도 좋습니다. -->

#### 🔥 작업사항

- api 응답값 null 일때 처리

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

- P1: 꼭 반영해주세요 (Comment)
- P2: 적극적으로 고려해주세요 (Comment)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)

## 🙋‍♂️ PR 담당자 리마인더

- [ ] 위의 P5 Rule을 숙지 하셨나요?

## 기타 사항

- 일반 머지 (Create a merge commit) 방식으로 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes in the Keyword statistics section when action category data is missing.
  * Gracefully handles absent positive/negative action categories, displaying empty values instead of causing errors.
  * Improved resilience when loading incomplete data from the API, ensuring the section renders reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->